### PR TITLE
Fix a bug which caused UPS patch creation to create incorrect patches

### DIFF
--- a/libups/libups.cpp
+++ b/libups/libups.cpp
@@ -42,7 +42,7 @@ bool UPS::create(const char *x, const char *y, const char *z) {
       }
 
       x = i < sizex ? xread() : 0x00;
-      y = y < sizey ? yread() : 0x00;
+      y = i < sizey ? yread() : 0x00;
       i++;
       zwrite(x ^ y);
       if(x == y) break;


### PR DESCRIPTION
I noticed that MultiPatch had a bug creating UPS patches. It looks like a typo is causing it to sometimes read an empty byte instead of the byte from the "after" file.