### PR TITLE
Unify spelling of MultiPatch

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Multi Patch</string>
+	<string>MultiPatch</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MultiPatch
-Multi Patch is an all-in-one file patching utility for macOS. 
+MultiPatch is an all-in-one file patching utility for macOS. 
 
 ## Supported formats
 Supported patch formats are automatically detected based on the file extension of the patch. At this time, please ensure the patches you wish to use have the proper extension.  
@@ -12,7 +12,7 @@ BPS: .bps
 Ninja2: .rup  
 
 ## License
-Multi Patch is built using open source code taken from various sources. The code for each patching algorithm used falls under different licenses, and any changes made will need to adhere to the specific license for that code. The Multi Patch application itself is released under the GPL in an effort to be compatible with the licenses of the patching libraries contained within. The licenses employed by each patching library used are listed below:
+MultiPatch is built using open source code taken from various sources. The code for each patching algorithm used falls under different licenses, and any changes made will need to adhere to the specific license for that code. The MultiPatch application itself is released under the GPL in an effort to be compatible with the licenses of the patching libraries contained within. The licenses employed by each patching library used are listed below:
 
 **UPS, BPS and IPS use Floating IPS (FLIPS) by Alcaro.**  
 \- Released under the GPLv3.  

--- a/ReadMe.rtf
+++ b/ReadMe.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1671\cocoasubrtf200
+{\rtf1\ansi\ansicpg1252\cocoartf1671\cocoasubrtf500
 \cocoascreenfonts1{\fonttbl\f0\fnil\fcharset0 HelveticaNeue;\f1\fswiss\fcharset0 Helvetica;\f2\fnil\fcharset0 HelveticaNeue-Bold;
 }
 {\colortbl;\red255\green255\blue255;}
@@ -6,13 +6,13 @@
 \margl1440\margr1440\vieww11020\viewh8400\viewkind0
 \pard\tx720\tx1440\tx2160\tx2250\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f0\fs36 \cf0 \uldb \ulc0 Multi Patch 1.7
+\f0\fs36 \cf0 \uldb \ulc0 MultiPatch 1.7
 \f1\fs24 \ulnone \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 \cf0 \
 
 \f0 \ul Overview\ulnone \
-Multi Patch is a patch utility for macOS. If you downloaded this, you probably already know that. Multi Patch is free software made up of several open source projects under varying licenses. See the license and source code sections below for more details.\
+MultiPatch is a patch utility for macOS. If you downloaded this, you probably already know that. MultiPatch is free software made up of several open source projects under varying licenses. See the license and source code sections below for more details.\
 \
 \ul System Requirements\ulnone \
 1. Any system running macOS 10.7 or greater.\
@@ -44,7 +44,7 @@ BPS Patch creation offers two different options, Linear and Delta. Linear BPS pa
 Patch creation for the UPS, PPF and Ninja2 formats is not supported. These formats are no longer recommended for new patches because BPS provides smaller patch files that compress more efficiently. For larger files XDelta is a popular choice.\
 \
 \ul License\ulnone \
-Multi Patch is built using open source code taken from various sources. The code for each patching algorithm used falls under different licenses, and any changes made will need to adhere to the specific license for that code. The Multi Patch application itself is released under the GPL in an effort to be compatible with the licenses of the patching libraries contained within. The licenses employed by each patching library used are listed below:\
+MultiPatch is built using open source code taken from various sources. The code for each patching algorithm used falls under different licenses, and any changes made will need to adhere to the specific license for that code. The MultiPatch application itself is released under the GPL in an effort to be compatible with the licenses of the patching libraries contained within. The licenses employed by each patching library used are listed below:\
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
@@ -72,7 +72,7 @@ Multi Patch is built using open source code taken from various sources. The code
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 \cf0 \ul Source Code\ulnone \
-The latest source code to Multi Patch is available on GitHub:\
+The latest source code to MultiPatch is available on GitHub:\
 https://github.com/Sappharad/MultiPatch/\
 \
 If you have changes that you'd like to contribute to the application, pull requests are welcome.\


### PR DESCRIPTION
This replaces all instances of "Multi Patch" with "MultiPatch" to unify the branding.